### PR TITLE
Add sudo wrapper for allowing STDOUT configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,16 @@ FROM alpine
 
 MAINTAINER Chris Fordham <chris@fordham.id.au>
 
-RUN apk add --no-cache --update squid
+RUN apk add --no-cache --update squid sudo && \
+    echo -e "Defaults:squid !requiretty" > /etc/sudoers.d/squid &&\
+    echo -e "squid ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/squid
 
 VOLUME /etc/squid
 VOLUME /var/cache/squid
 VOLUME /var/log/squid
 
-EXPOSE 3128
 
-CMD ["squid", "-N", "-d1"]
+EXPOSE 3128
+USER squid
+
+CMD ["sudo", "squid", "-N", "-d1"]


### PR DESCRIPTION
This adds the sudo package to the squid proxy in order to allow the
main squid process to access STDOUT before it drops privileges when
forking.